### PR TITLE
Add Baton activity stream

### DIFF
--- a/tap_hellobaton/schemas/activity.json
+++ b/tap_hellobaton/schemas/activity.json
@@ -1,0 +1,45 @@
+{
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "_self": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    },
+    "group": {
+      "type": "string"
+    },
+    "parent": {
+      "type": "string"
+    },
+    "child": {
+      "type": "string"
+    },
+    "actor": {
+      "type": "string"
+    },
+    "project": {
+      "type": "string"
+    },
+    "parent_type": {
+      "type": "string"
+    },
+    "child_type": {
+      "type": "string"
+    },
+    "meta": {
+      "type": "string"
+    },
+    "created": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "modified": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/tap_hellobaton/schemas/activity.json
+++ b/tap_hellobaton/schemas/activity.json
@@ -13,22 +13,37 @@
       "type": "string"
     },
     "parent": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "child": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "actor": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "project": {
       "type": "string"
     },
     "parent_type": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "child_type": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "meta": {
       "type": "string"

--- a/tap_hellobaton/streams.py
+++ b/tap_hellobaton/streams.py
@@ -75,3 +75,10 @@ class UsersStream(hellobatonStream):
     path = "/users/"
     primary_keys = ["id"]
     schema_filepath = SCHEMAS_DIR / "users.json"
+
+class ActivityStream(hellobatonStream):
+    """Define custom stream."""
+    name = "activity"
+    path = "/activity/"
+    primary_keys = ["id"]
+    schema_filepath = SCHEMAS_DIR / "activity.json"

--- a/tap_hellobaton/tap.py
+++ b/tap_hellobaton/tap.py
@@ -15,7 +15,8 @@ from tap_hellobaton.streams import (
     TimeEntriesStream,
     UsersStream,
     TaskAttachmentsStream,
-    TemplatesStream
+    TemplatesStream,
+    ActivityStream
 )
 
 STREAM_TYPES = [
@@ -28,7 +29,8 @@ STREAM_TYPES = [
     TimeEntriesStream,
     UsersStream,
     TaskAttachmentsStream,
-    TemplatesStream
+    TemplatesStream,
+    ActivityStream
 ]
 
 class Taphellobaton(Tap):


### PR DESCRIPTION
Hey Dan! Thanks for getting this kicked off. One thing we added to our public API recently was the Baton activity stream. Baton's Activity contains all sorts of helpful historical information about tasks.

hth, and let me know how and if you'd like us to contribute or maintain this!