### PR TITLE
Fixing activity stream schema definition

### DIFF
--- a/tap_hellobaton/schemas/activity.json
+++ b/tap_hellobaton/schemas/activity.json
@@ -47,7 +47,7 @@
     },
     "meta": {
       "type": [
-        "string",
+        "object",
         "null"
         ]
     },


### PR DESCRIPTION
The empty json object is still type object and this is causing an error with the pipeline