### PR TITLE
Minor version 0.0.3 w/ new endpoints and updated dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup, find_packages
 
 setup(
     name='tap-hellobaton',
-    version='0.0.2',
+    version='0.0.3',
     description='Singer.io tap for extracting data from the Hello Baton API',
     author='Daniel Luftspring',
     py_modules=['tap_hellobaton'],
     install_requires=[
-        'singer-sdk>=0.3.9',
+        'singer-sdk>=0.3.17',
         'requests>=2.26.0',
         'urllib3>=1.26.7',
         'jsonschema>=3.2.0'

--- a/tap_hellobaton/schemas/comments.json
+++ b/tap_hellobaton/schemas/comments.json
@@ -1,0 +1,33 @@
+{
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "_self": {
+            "type": "string"
+        },
+        "author": {
+            "type": "string"
+        },
+        "task": {
+            "type": "string"
+        },
+        "project": {
+            "type": "string"
+        },
+        "content": {
+            "type": "string"
+        },
+        "is_internal": {
+            "type": "boolean"
+        },
+        "created": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "modified": {
+            "type": "string",
+            "format": "date-time"
+        }
+    }
+}

--- a/tap_hellobaton/schemas/custom_field_options.json
+++ b/tap_hellobaton/schemas/custom_field_options.json
@@ -1,0 +1,33 @@
+{
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "_self": {
+            "type": "string"
+        },
+        "field": {
+            "type": "string"
+        },
+        "value": {
+            "type": "string"
+        },
+        "default": {
+            "type": "boolean"
+        },
+        "archived": {
+            "type": "boolean"
+        },
+        "created_by": {
+            "type": "string"
+        },
+        "created": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "modified": {
+            "type": "string",
+            "format": "date-time"
+        }
+    }
+}

--- a/tap_hellobaton/schemas/custom_field_values.json
+++ b/tap_hellobaton/schemas/custom_field_values.json
@@ -1,0 +1,58 @@
+{
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "_self": {
+            "type": "string"
+        },
+        "project": {
+            "type": "string"
+        },
+        "field": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "_self": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "value_numeric": {
+            "type": ["integer", "null"]
+        },
+        "selected_option": {
+            "type": ["object", "nulll"],
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "_self": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                },
+                "default": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "created": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "modified": {
+            "type": "string",
+            "format": "date-time"
+        }
+    }
+}

--- a/tap_hellobaton/schemas/custom_fields.json
+++ b/tap_hellobaton/schemas/custom_fields.json
@@ -1,0 +1,48 @@
+{
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "_self": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": ["string", "null"]
+        },
+        "visibility": {
+            "type": "string"
+        },
+        "type": {
+            "type": "string"
+        },
+        "required": {
+            "type": "boolean"
+        },
+        "multiselect": {
+            "type": "boolean"
+        },
+        "number_scale": {
+            "type": "integer"
+        },
+        "number_display": {
+            "type": "string"
+        },
+        "options": {
+            "type": ["string", "null"]
+        },
+        "created_by": {
+            "type": "string"
+        },
+        "created": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "modified": {
+            "type": "string",
+            "format": "date-time"
+        }
+    }
+}

--- a/tap_hellobaton/streams.py
+++ b/tap_hellobaton/streams.py
@@ -82,3 +82,31 @@ class ActivityStream(hellobatonStream):
     path = "/activity/"
     primary_keys = ["id"]
     schema_filepath = SCHEMAS_DIR / "activity.json"
+
+class CommentsStream(hellobatonStream):
+    """Define custom stream."""
+    name = "comments"
+    path = "/comments/"
+    primary_keys = ["id"]
+    schema_filepath = SCHEMAS_DIR / "comments.json"
+
+class CustomFieldsStream(hellobatonStream):
+    """Define custom stream."""
+    name = "custom_fields"
+    path = "/custom_fields/"
+    primary_keys = ["id"]
+    schema_filepath = SCHEMAS_DIR / "custom_fields.json"
+
+class CustomFieldOptionsStream(hellobatonStream):
+    """Define custom stream."""
+    name = "custom_field_options"
+    path = "/custom_field_options/"
+    primary_keys = ["id"]
+    schema_filepath = SCHEMAS_DIR / "custom_field_options.json"
+
+class CustomFieldValuesStream(hellobatonStream):
+    """Define custom stream."""
+    name = "custom_field_values"
+    path = "/custom_field_values/"
+    primary_keys = ["id"]
+    schema_filepath = SCHEMAS_DIR / "custom_field_values.json"

--- a/tap_hellobaton/tap.py
+++ b/tap_hellobaton/tap.py
@@ -16,7 +16,11 @@ from tap_hellobaton.streams import (
     UsersStream,
     TaskAttachmentsStream,
     TemplatesStream,
-    ActivityStream
+    ActivityStream,
+    CommentsStream,
+    CustomFieldsStream,
+    CustomFieldValuesStream,
+    CustomFieldOptionsStream
 )
 
 STREAM_TYPES = [
@@ -30,7 +34,11 @@ STREAM_TYPES = [
     UsersStream,
     TaskAttachmentsStream,
     TemplatesStream,
-    ActivityStream
+    ActivityStream,
+    CommentsStream,
+    CustomFieldsStream,
+    CustomFieldValuesStream,
+    CustomFieldOptionsStream
 ]
 
 class Taphellobaton(Tap):


### PR DESCRIPTION
## Description

This PR:

* Adds endpoint support for
    - /custom_fields
    - /custom_field_values
    - /custom_field_options
    - /comments
* Updates underlying dependency on singer-sdk to version 0.3.17

## How to test

Re install and verify the dependency updates
```bash
~$ pip install . && tap-hellobaton --version
```

Run the tap
```bash
~$ tap-hellobaton --config .secrets/YOUR_SECRET_FILE > ~/Desktop/sample_baton_output.json
```